### PR TITLE
Add GlobalRepresentation for SOAP with option for averaging mode.

### DIFF
--- a/cscribe/soap.py
+++ b/cscribe/soap.py
@@ -75,3 +75,71 @@ class SOAP(Representation):
         )
 
         return to_local(data, rep)
+
+
+class SOAPAveraged(Representation):
+    """SOAP Representation (implemented in DScribe), averaging over atoms.
+
+    For details, see https://singroup.github.io/dscribe/tutorials/soap.html
+    or the dscribe source.
+
+    Parameters:
+        elems: Elements for which we compute SOAP
+        cutoff: Cutoff radius
+        sigma: Broadening
+        n_max: Number of radial basis functions
+        l_max: Number of angular basis functions
+        rbf: Radial basis set. Either "gto" for Gaussians,
+            or "polynomial" for a polynomial basis set more
+            similar to the "original" SOAP approach.
+        avg: Averaging mode over centers of interest. Either
+             "inner" (average before summing magnetic quantum numbers)
+             or "outer" (average over power spectrum of different sites).
+    """
+
+    kind = "ds_soapavg"
+    default_context = {"n_jobs": 1, "verbose": False}
+
+    def __init__(self, elems, cutoff, sigma, n_max, l_max,
+                 rbf="gto", avg="outer", context={}):
+        super().__init__(context=context)
+        
+        self.config = {"elems": elems,
+                       "cutoff": cutoff,
+                       "sigma": sigma,
+                       "n_max": n_max,
+                       "l_max": l_max,
+                       "rbf": rbf, 
+                       "avg": "outer",}
+        assert self.config["average"] is not "off", "Invalid configuration".
+
+    def _get_config(self):
+        return self.config
+
+    def compute(self, data):
+        if data.b is None:
+            ds_soap = dsSOAP(species=self.config["elems"],
+                             rcut=self.config["cutoff"],
+                             nmax=self.config["n_max"],
+                             lmax=self.config["l_max"],
+                             sigma=self.config["sigma"],
+                             rbf=self.config["rbf"],
+                             crossover=True,
+                             periodic=False,
+                             average=self.config["avg"])
+        else:
+            ds_soap = dsSOAP(species=self.config["elems"],
+                             rcut=self.config["cutoff"],
+                             nmax=self.config["n_max"],
+                             lmax=self.config["l_max"],
+                             sigma=self.config["sigma"],
+                             rbf=self.config["rbf"],
+                             crossover=True,
+                             periodic=True,
+                             average=self.config["avg"])
+
+        rep = ds_soap.create(data.as_Atoms(),
+                             n_jobs=self.context["n_jobs"],
+                             verbose=self.context["verbose"], )
+        return rep
+


### PR DESCRIPTION
DScribe recently [expanded the options for averaging over atoms in the SOAP representation](https://github.com/SINGROUP/dscribe/blob/90aa6c4b1397a223f1330e8bb93bbb24726e8078/dscribe/descriptors/soap.py#L95-L100) in release 0.4.0.

It would be nice to have a cmlkit.representation.GlobalRepresentation for SOAP in cscribe that includes the inner/outer option in its config. Here's my first attempt.